### PR TITLE
Deletion of domains generating problems with Spotify App

### DIFF
--- a/Lists/adguard.txt
+++ b/Lists/adguard.txt
@@ -1,10 +1,10 @@
 #######################################################################################
 ##### Spotify Ads Blacklist                                                        ####
 ##### Created by: Isaaker                                                          ####
-##### Revised: 27/1/24                                                             ####
+##### Revised: 19/4/24                                                             ####
 #######################################################################################
 ##### Version: Adguard                                                             ####
-##### Number of domains: 1562                                                      ####
+##### Number of domains: 1559                                                      ####
 #######################################################################################
 ##### Read more: https://github.com/Isaaker/Spotify-AdsList                        ####
 ##### License: https://github.com/Isaaker/Spotify-AdsList/blob/main/LICENSE.txt    ####
@@ -907,7 +907,6 @@
 ||messenger-webview.scdn.co ^
 ||metadatafeedback.spotify.com ^
 ||mobile-001.lon.spotify.com ^
-||mobile-ap.spotify.com ^
 ||mobile.spotify.com ^
 ||mosaic.scdn.co ^
 ||mp3ad.scdn.co ^
@@ -1564,10 +1563,8 @@
 ||e10499.dsce9.akamaiedge.net^
 ||clients1.google.com^
 ||audio4-ak-spotify-com.akamaized.net^
-||edge-web.dual-gslb.spotify.com^
 ||sp-bootstrap.global.ssl.fastly.net^
 ||e12919.dscd.akamaiedge.net^
-||mobile-ap.spotify.com^
 ||star.c10r.facebook.com^
 ||ap.spotify.com^
 ||a1744.dscw154.akamai.net^

--- a/Lists/dnsmasq.txt
+++ b/Lists/dnsmasq.txt
@@ -1,10 +1,10 @@
 #######################################################################################
 ##### Spotify Ads Blacklist                                                        ####
 ##### Created by: Isaaker                                                          ####
-##### Revised: 27/1/24                                                             ####
+##### Revised: 19/4/24                                                             ####
 #######################################################################################
 ##### Version: dnsmasq                                                             ####
-##### Number of domains: 1562                                                      ####
+##### Number of domains: 1559                                                      ####
 #######################################################################################
 ##### Read more: https://github.com/Isaaker/Spotify-AdsList                        ####
 ##### License: https://github.com/Isaaker/Spotify-AdsList/blob/main/LICENSE.txt    ####
@@ -905,7 +905,6 @@ server=/messenger-webhook.spotify.com/
 server=/messenger-webview.scdn.co/
 server=/metadatafeedback.spotify.com/
 server=/mobile-001.lon.spotify.com/
-server=/mobile-ap.spotify.com/
 server=/mobile.spotify.com/
 server=/mosaic.scdn.co/
 server=/mp3ad.scdn.co/
@@ -1562,10 +1561,8 @@ server=/a2047.dscapi9.akamai.net/
 server=/e10499.dsce9.akamaiedge.net/
 server=/clients1.google.com/
 server=/audio4-ak-spotify-com.akamaized.net/
-server=/edge-web.dual-gslb.spotify.com/
 server=/sp-bootstrap.global.ssl.fastly.net/
 server=/e12919.dscd.akamaiedge.net/
-server=/mobile-ap.spotify.com/
 server=/star.c10r.facebook.com/
 server=/ap.spotify.com/
 server=/a1744.dscw154.akamai.net/

--- a/Lists/pi-hole.txt
+++ b/Lists/pi-hole.txt
@@ -1,10 +1,10 @@
 #######################################################################################
 ##### Spotify Ads Blacklist                                                        ####
 ##### Created by: Isaaker                                                          ####
-##### Revised: 27/1/24                                                             ####
+##### Revised: 19/4/24                                                             ####
 #######################################################################################
 ##### Version: pi-hole                                                             ####
-##### Number of domains: 1562                                                      ####
+##### Number of domains: 1559                                                      ####
 #######################################################################################
 ##### Read more: https://github.com/Isaaker/Spotify-AdsList                        ####
 ##### License: https://github.com/Isaaker/Spotify-AdsList/blob/main/LICENSE.txt    ####
@@ -906,7 +906,6 @@ messenger-webhook.spotify.com
 messenger-webview.scdn.co 
 metadatafeedback.spotify.com 
 mobile-001.lon.spotify.com 
-mobile-ap.spotify.com 
 mobile.spotify.com 
 mosaic.scdn.co 
 mp3ad.scdn.co 
@@ -1563,10 +1562,8 @@ a2047.dscapi9.akamai.net
 e10499.dsce9.akamaiedge.net
 clients1.google.com
 audio4-ak-spotify-com.akamaized.net
-edge-web.dual-gslb.spotify.com
 sp-bootstrap.global.ssl.fastly.net
 e12919.dscd.akamaiedge.net
-mobile-ap.spotify.com
 star.c10r.facebook.com
 ap.spotify.com
 a1744.dscw154.akamai.net

--- a/Lists/standard_list.txt
+++ b/Lists/standard_list.txt
@@ -1,10 +1,10 @@
 #######################################################################################
 ##### Spotify Ads Blacklist                                                        ####
 ##### Created by: Isaaker                                                          ####
-##### Revised: 27/1/24                                                             ####
+##### Revised: 19/4/24                                                             ####
 #######################################################################################
 ##### Version: Standard                                                            ####
-##### Number of domains: 1562                                                      ####
+##### Number of domains: 1559                                                      ####
 #######################################################################################
 ##### Read more: https://github.com/Isaaker/Spotify-AdsList                        ####
 ##### License: https://github.com/Isaaker/Spotify-AdsList/blob/main/LICENSE.txt    ####
@@ -905,7 +905,6 @@
 0.0.0.0 messenger-webview.scdn.co 
 0.0.0.0 metadatafeedback.spotify.com 
 0.0.0.0 mobile-001.lon.spotify.com 
-0.0.0.0 mobile-ap.spotify.com 
 0.0.0.0 mobile.spotify.com 
 0.0.0.0 mosaic.scdn.co 
 0.0.0.0 mp3ad.scdn.co 
@@ -1562,10 +1561,8 @@
 0.0.0.0 e10499.dsce9.akamaiedge.net
 0.0.0.0 clients1.google.com
 0.0.0.0 audio4-ak-spotify-com.akamaized.net
-0.0.0.0 edge-web.dual-gslb.spotify.com
 0.0.0.0 sp-bootstrap.global.ssl.fastly.net
 0.0.0.0 e12919.dscd.akamaiedge.net
-0.0.0.0 mobile-ap.spotify.com
 0.0.0.0 star.c10r.facebook.com
 0.0.0.0 ap.spotify.com
 0.0.0.0 a1744.dscw154.akamai.net

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here you can find all the tests made, their date and more details.
 | Web App | Virtual Machine | Debian 12 | Chromium (121.0.6167.85)| 27/1/24 | ![Static Badge](https://img.shields.io/badge/Status-ERROR-red?logo=spotify) | pihole |
 | App | Mac | MacOS (14.2.1) | - | 27/1/24 | ![Static Badge](https://img.shields.io/badge/Status-OK-green?logo=spotify) | pihole |
 | App | iPhone | iOS (17.3.1) | - | 15/2/24 | ![Static Badge](https://img.shields.io/badge/Status-OK-green?logo=spotify) | pihole |
-| App | Google Pixel 4a | Android 13 | - | 19/4/24 | ![Static Badge](https://img.shields.io/badge/Status-ERROR-red?logo=spotify) | adguard |
+| App | Google Pixel 4a | Android 13 | - | 20/4/24 | ![Static Badge](https://img.shields.io/badge/Status-OK-green?logo=spotify) | adguard |
 
 **If you have tested the list, please create a issue with type "Testing" to add more tested devices. [Add new tested device](https://github.com/Isaaker/Spotify-AdsList/issues/new?assignees=&labels=Testing&projects=&template=testing.yml&title=New+Testing+Device%3A+%5BDevice+Name%5D+%2F+%5BDevice+OS%26Version%5D)**
 


### PR DESCRIPTION
**Closes #3 issue related to some domains that caused multiple anomalies in the Spotify app for Google Pixel 4a / Android 13.**

## About

The first domain to be removed was ```edge-web.dual-gslb.spotify.com```, which was redirected via a CNAME entry in the DNS domain ```login5.spotify.com```, and which apparently handled the user authentication process.

The ````mobile-ap.spotify.com``` domain, which was responsible for checking if the app was connected to Spotify's servers, and therefore blocking it caused an anomaly in the application, is also removed.

Finally the Google Pixel 4a device was added to the Testing section of the README as a working device, after verifying that the app was now working correctly.

Thanks to @mfjt for the report.