### PR TITLE
Add gew4-spclient.spotify.com to whitelist

### DIFF
--- a/Lists/WHITELIST.txt
+++ b/Lists/WHITELIST.txt
@@ -8,3 +8,4 @@ audio4-fa.scdn.co
 seektables.scdn.co
 cast.scdn.co
 audio4-ak.spotifycdn.com
+gew4-spclient.spotify.com


### PR DESCRIPTION
While not blocked by this blocklists, some blocklists do and people might assume it comes from here.

So best to explicitly whitelist