### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -1,4 +1,5 @@
 name: MkDocs Deploy Cloudflare
+permissions: read-all
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/Isaaker/Spotify-AdsList/security/code-scanning/4](https://github.com/Isaaker/Spotify-AdsList/security/code-scanning/4)

To fix the problem, add a `permissions` block to the workflow file. This can be done at the top level (applies to all jobs) or at the job level (applies to a specific job). Since neither job appears to require write access to the repository (the `scan` job runs gitleaks, and the `build` job runs a deployment command from a secret), the minimal safe default is `permissions: read-all`. If a job later requires more specific permissions, they can be added at the job level. The best fix is to add `permissions: read-all` at the top level, immediately after the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
