### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_blocklist.yml
+++ b/.github/workflows/build_blocklist.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: Build Blocklist
+permissions:
+  contents: write
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Isaaker/Spotify-AdsList/security/code-scanning/1](https://github.com/Isaaker/Spotify-AdsList/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow, either at the root level (to apply to all jobs) or at the job level (to apply to a specific job). The minimal starting point is `contents: read`, but since the workflow pushes changes to the repository (using `git push`), it requires `contents: write` permission. If the workflow also interacts with pull requests, you may need to add `pull-requests: write`, but in this case, only `contents: write` is strictly necessary for the push operation. The change should be made at the root level, immediately after the `name:` field and before the `on:` field, or at the job level under the `build:` job. The best practice is to set it at the root level unless different jobs require different permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
