### PR TITLE
Changed whitelist link to point to MkDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The list is highly compatible, so here are the different versions so that you ca
 
 In order for Spotify to function properly, a short list of domains needs to be added to its whitelist to prevent redirects from blocked to non-blocked domains from being cut off.
 
-See the Whitelist [here](https://github.com/Isaaker/Spotify-AdsList/blob/main/Lists/WHITELIST.txt)
+See the Whitelist [here](https://spotify.piscinadeentropia.es/docs_whitelist/)
 
 ## Testing
 


### PR DESCRIPTION
# About

Current link for the whitelist is invalid as it points to WHITELIST.md which was removed in the commit c21d6e3dc465a490fd3a465a70f94fbaa123af7f and merged in #69 for the 2.0.0 release.

# Issues

We worked in the following issues on the Pull Request:
* #90 

# Requirements
Please check these requirements:
**pull requests that do not meet these requirements will not be accepted under any circumstances**
- [x] The content I want to contribute is appropriate ([Read more](https://spotify.piscinadeentropia.es/docs_contributing/#content-to-collaborate-with))
- [x] I agree that my contributions are licensed and I accept the [terms and conditions of the license](https://spotify.piscinadeentropia.es/docs_license/)
- [x] I accept the [code of conduct](https://github.com/Isaaker/Spotify-AdsList/blob/main/CODE_OF_CONDUCT.md)
- [x] I read the documentation on [how to contribute](https://spotify.piscinadeentropia.es/docs_contributing/)
- [x] I have checked that the pull is not being performed against main
- [x] I agree to be listed as a contributor of the repository. [Learn more...](https://spotify.piscinadeentropia.es/docs_contributing/#appear-as-a-contributor)

# Co-Authored

List the people who contributed to your PR, otherwise leave blank.

# More information

If you want more information about this pull request, don't be afraid of [opening a new issue with the label "question"](https://github.com/Isaaker/Spotify-AdsList/issues/new?assignees=isaaker&labels=question) or asking here (if the PR is still open).
